### PR TITLE
Implement EQ preset switching

### DIFF
--- a/Client/src/App.cpp
+++ b/Client/src/App.cpp
@@ -32,10 +32,10 @@ bool App::OnImGui()
                         // Not very useful for now, disabled unless debugging
                         break;
 #endif
-                    case HeadphonesEvent::HeadphoneInteractionEvent:                    
+                    case HeadphonesEventType::InteractionUpdate:                    
                         _handleHeadphoneInteraction(std::get<std::string>(event.message));                    
                         break;
-                    case HeadphonesEvent::PlaybackMetadataUpdate:
+                    case HeadphonesEventType::PlaybackMetadataUpdate:
                         _logs.push_back("Now Playing: " + _headphones->playback.title);
                         break;
                 default:

--- a/Client/src/App.cpp
+++ b/Client/src/App.cpp
@@ -23,7 +23,7 @@ bool App::OnImGui()
             {
                 // Polling & state updates are only done on the main thread
                 auto event = _headphones->poll();
-                switch (event.type)
+                switch (event)
                 {
 #ifdef _DEBUG
                     case HeadphonesEvent::JSONMessage:
@@ -32,10 +32,10 @@ bool App::OnImGui()
                         // Not very useful for now, disabled unless debugging
                         break;
 #endif
-                    case HeadphonesEventType::InteractionUpdate:                    
-                        _handleHeadphoneInteraction(std::get<std::string>(event.message));                    
+                    case HeadphonesEvent::InteractionUpdate:                    
+                        _handleHeadphoneInteraction(_headphones->interactionMessage.current);
                         break;
-                    case HeadphonesEventType::PlaybackMetadataUpdate:
+                    case HeadphonesEvent::PlaybackMetadataUpdate:
                         _logs.push_back("Now Playing: " + _headphones->playback.title);
                         break;
                 default:
@@ -300,6 +300,48 @@ void App::_drawControls()
             }
 
             if (ImGui::BeginTabItem("Equalizer")) {
+                static const std::map<int, std::string> EQ_PRESET_NAMES = {
+                    { 0, "Off" },
+                    { 1, "Rock" },
+                    { 2, "Pop" },
+                    { 3, "Jazz" },
+                    { 4, "Dance" },
+                    { 5, "EDM" },
+                    { 6, "R&B/Hip-Hop" },
+                    { 7, "Acoustic" },
+                    // 8-15 reserved for future use
+                    { 16, "Bright" },
+                    { 17, "Excited" },
+                    { 18, "Mellow" },
+                    { 19, "Relaxed" },
+                    { 20, "Vocal" },
+                    { 21, "Treble" },
+                    { 22, "Bass" },
+                    { 23, "Speech" },
+                    // 24-31 reserved for future use
+                    { 0xa0, "Custom" },
+                    { 0xa1, "User Setting 1" },
+                    { 0xa2, "User Setting 2" },
+                    { 0xa3, "User Setting 3" },
+                    { 0xa4, "User Setting 4" },
+                    { 0xa5, "User Setting 5" }
+                };
+                static std::string presetName = "Unknown";
+                auto it = EQ_PRESET_NAMES.find(_headphones->eqPreset.current);
+                if (it != EQ_PRESET_NAMES.end())
+                    presetName = it->second;
+                if (ImGui::BeginCombo("Preset", presetName.c_str()))
+                {
+                    for (auto const& [k, v] : EQ_PRESET_NAMES)
+                    {
+                        bool is_selected = k == _headphones->eqPreset.current;
+                        if (ImGui::Selectable(v.c_str(), is_selected))
+                            _headphones->eqPreset.desired = k;
+                        if (is_selected)
+                            ImGui::SetItemDefaultFocus();
+                    }
+                    ImGui::EndCombo();
+                }
                 const float width = ImGui::GetContentRegionAvail().x;
                 const float padding = ImGui::GetStyle().ItemSpacing.x;
                 ImGui::SeparatorText("5-Band EQ");
@@ -321,13 +363,12 @@ void App::_drawControls()
             if (ImGui::BeginTabItem("Multipoint")) {
                 ImGui::Checkbox("Multipoint Connect", &_headphones->mpEnabled.desired);
                 ImGui::Text("NOTE: Can't toggle yet. Sorry!");
-                size_t i = 0;
                 const auto default_flags = ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_NoTreePushOnOpen;
                 for (auto& [mac, device] : _headphones->connectedDevices) {
                     if (mac == _headphones->mpDeviceMac.current)
-                        ImGui::TreeNodeEx((void*)i++, default_flags | ImGuiTreeNodeFlags_Selected, "%s", device.name.c_str());
+                        ImGui::TreeNodeEx(&mac, default_flags | ImGuiTreeNodeFlags_Selected, "%s", device.name.c_str());
                     else
-                        ImGui::TreeNodeEx((void*)i++, default_flags, "%s", device.name.c_str());
+                        ImGui::TreeNodeEx(&mac, default_flags, "%s", device.name.c_str());
                     if (ImGui::IsItemClicked()) {
                         _headphones->mpDeviceMac.desired = mac;
                     }
@@ -411,12 +452,12 @@ void App::_drawConfig()
                 for (
                     auto it = cmds.begin();it != cmds.end();it != cmds.end() ? it++ : cmds.end()) {
                     ImGui::TableNextRow();
-                    ImGui::PushID((void*)it->first.data());
+                    ImGui::PushID(it->first.data());
                     ImGui::TableSetColumnIndex(0);
                     ImGui::InputText("##", &it->first);
                     ImGui::PopID();
 
-                    ImGui::PushID((void*)it->second.data());
+                    ImGui::PushID(it->second.data());
                     ImGui::TableSetColumnIndex(1);
                     ImGui::InputText("##", &it->second);
                     ImGui::TableSetColumnIndex(2);

--- a/Client/src/BluetoothWrapper.cpp
+++ b/Client/src/BluetoothWrapper.cpp
@@ -89,7 +89,7 @@ void BluetoothWrapper::recvCommand(CommandSerializer::CommandMessage& msg)
 	msg.messageBytes[2] = recvOne(); // seqNumber
 	this->_seqNumber = msg.getSeqNumber();
 
-	this->connector->recv(&msg.messageBytes[3], 4);
+	this->connector->recv(reinterpret_cast<char*>(&msg.messageBytes[3]), 4);
 	while (msg.messageBytes.back() != END_MARKER) 
 		msg.messageBytes.push_back(recvOne()); 
 	

--- a/Client/src/ByteMagic.h
+++ b/Client/src/ByteMagic.h
@@ -17,7 +17,7 @@ inline unsigned int byteOrderSwap(unsigned int num)
         (num << 24);
 }
 
-inline int bytesToIntBE(const char* buf) {
+inline int bytesToIntBE(const unsigned char* buf) {
     return ((int)buf[3] & 0xFF) | (((int)buf[2] << 8) & 0x0000FF00) | (((int)buf[1] << 16) & 0x00FF0000) | (((int)buf[0] << 24) & 0xFF000000);
 }
 

--- a/Client/src/CommandSerializer.cpp
+++ b/Client/src/CommandSerializer.cpp
@@ -1,9 +1,9 @@
 #include "CommandSerializer.h"
 
-constexpr unsigned char ESCAPED_BYTE_SENTRY = 0x3D;
-constexpr unsigned char ESCAPED_60 = 44; // 0x3C -> 0x3D 0x2C
-constexpr unsigned char ESCAPED_61 = 45; // 0x3D -> 0x3D 0x2D
-constexpr unsigned char ESCAPED_62 = 46; // 0x3E -> 0x3D 0x2E
+constexpr uint8_t ESCAPED_BYTE_SENTRY = 0x3D;
+constexpr uint8_t ESCAPED_60 = 44; // 0x3C -> 0x3D 0x2C
+constexpr uint8_t ESCAPED_61 = 45; // 0x3D -> 0x3D 0x2D
+constexpr uint8_t ESCAPED_62 = 46; // 0x3E -> 0x3D 0x2E
 constexpr int MAX_STEPS_WH_1000_XM3 = 19;
 
 namespace CommandSerializer
@@ -84,9 +84,9 @@ namespace CommandSerializer
 		return ret;
 	}
 
-	unsigned char _sumChecksum(const char* src, size_t size)
+	uint8_t _sumChecksum(const uint8_t* src, size_t size)
 	{
-		unsigned char accumulator = 0;
+		uint8_t accumulator = 0;
 		for (size_t i = 0; i < size; i++)
 		{
 			accumulator += src[i];
@@ -94,7 +94,7 @@ namespace CommandSerializer
 		return accumulator;
 	}
 
-	unsigned char _sumChecksum(const Buffer& src)
+	uint8_t _sumChecksum(const Buffer& src)
 	{
 		return _sumChecksum(src.data(), src.size());
 	}
@@ -106,7 +106,7 @@ namespace CommandSerializer
 		toEscape.reserve(src.size() + 2 + sizeof(int));
 		Buffer ret;
 		ret.reserve(toEscape.capacity());
-		toEscape.push_back(static_cast<unsigned char>(dataType));
+		toEscape.push_back(static_cast<uint8_t>(dataType));
 		toEscape.push_back(seqNumber);
 		auto retSize = intToBytesBE(static_cast<unsigned int>(src.size()));
 		//Insert data size
@@ -137,19 +137,19 @@ namespace CommandSerializer
 	{
 		// 0x68 | 0x17 | [Not Dragging ASM Slider?] | [NC & ASM On?] | [NC:0 ASM:1] | [Voice Passthrough?] | [ASM Level]
 		Buffer ret;
-		ret.push_back(static_cast<unsigned char>(COMMAND_TYPE::NCASM_PARAM_SET)); // 0x68		
+		ret.push_back(static_cast<uint8_t>(COMMAND_TYPE::NCASM_PARAM_SET)); // 0x68		
 		ret.push_back(0x17);
 		ret.push_back(0x01);
-		ret.push_back(static_cast<unsigned char>(ncAsmEffect));
-		ret.push_back(static_cast<unsigned char>(ncAsmSettingType));
-		ret.push_back(static_cast<unsigned char>(voicePassthrough));
+		ret.push_back(static_cast<uint8_t>(ncAsmEffect));
+		ret.push_back(static_cast<uint8_t>(ncAsmSettingType));
+		ret.push_back(static_cast<uint8_t>(voicePassthrough));
 		ret.push_back(asmLevel);
 		return ret;
 	}
 
 	Buffer serializeVoiceGuidanceSetting(char volume) {
 		Buffer ret;
-		ret.push_back(static_cast<unsigned char>(COMMAND_TYPE::VOICEGUIDANCE_PARAM_SET));
+		ret.push_back(static_cast<uint8_t>(COMMAND_TYPE::VOICEGUIDANCE_PARAM_SET));
 		ret.push_back(0x20);
 		ret.push_back(volume); // Guidance Volume
 		ret.push_back(0x00);
@@ -158,7 +158,7 @@ namespace CommandSerializer
 	Buffer serializeVolumeSetting(char volume)
 	{
 		Buffer ret;
-		ret.push_back(static_cast<unsigned char>(COMMAND_TYPE::PLAYBACK_STATUS_SET));
+		ret.push_back(static_cast<uint8_t>(COMMAND_TYPE::PLAYBACK_STATUS_SET));
 		ret.push_back(0x20);
 		ret.push_back(volume); // Volume
 		return ret;
@@ -166,7 +166,7 @@ namespace CommandSerializer
 	Buffer serializeMultipointSwitch(const char* macString)
 	{
 		Buffer ret;
-		ret.push_back(static_cast<unsigned char>(COMMAND_TYPE::MULTIPOINT_DEVICE_SET));
+		ret.push_back(static_cast<uint8_t>(COMMAND_TYPE::MULTIPOINT_DEVICE_SET));
 		ret.push_back(0x01);
 		ret.insert(ret.end(), macString, macString + 6 * 3 - 1); // Mac string. e.g. XX:XX:XX:XX:XX:XX
 		return ret;
@@ -174,17 +174,17 @@ namespace CommandSerializer
 	Buffer serializePlayControl(PLAYBACK_CONTROL control)
 	{
 		Buffer ret;
-		ret.push_back(static_cast<unsigned char>(COMMAND_TYPE::PLAYBACK_STATUS_CONTROL_SET));
+		ret.push_back(static_cast<uint8_t>(COMMAND_TYPE::PLAYBACK_STATUS_CONTROL_SET));
 		ret.push_back(0x01);
 		ret.push_back(0x00);
-		ret.push_back(static_cast<unsigned char>(control));
+		ret.push_back(static_cast<uint8_t>(control));
 		return ret;
 	}
 
 	Buffer serializePowerOff()
 	{
 		Buffer ret;
-		ret.push_back(static_cast<unsigned char>(COMMAND_TYPE::POWER_OFF));
+		ret.push_back(static_cast<uint8_t>(COMMAND_TYPE::POWER_OFF));
 		ret.push_back(0x03);
 		ret.push_back(0x01);
 		return ret;
@@ -194,8 +194,8 @@ namespace CommandSerializer
 	Buffer serializeMpToggle(bool enabled)
 	{
 		Buffer ret;
-		ret.push_back(static_cast<unsigned char>(COMMAND_TYPE::MULTIPOINT_ETC_ENABLE_SET));
-		ret.push_back(static_cast<unsigned char>(0xD2));
+		ret.push_back(static_cast<uint8_t>(COMMAND_TYPE::MULTIPOINT_ETC_ENABLE_SET));
+		ret.push_back(static_cast<uint8_t>(0xD2));
 		ret.push_back(0x00);
 		ret.push_back(!enabled); // 1 (on->off) 0 (off->on)
 		return ret;
@@ -205,7 +205,7 @@ namespace CommandSerializer
 	Buffer serializeSpeakToChatConfig(char sensitivity, char timeout)
 	{
 		Buffer ret;
-		ret.push_back(static_cast<unsigned char>(COMMAND_TYPE::SPEAK_TO_CHAT_SET));
+		ret.push_back(static_cast<uint8_t>(COMMAND_TYPE::SPEAK_TO_CHAT_SET));
 		ret.push_back(0x0c);
 		ret.push_back(sensitivity);
 		ret.push_back(timeout);
@@ -215,7 +215,7 @@ namespace CommandSerializer
 	Buffer serializeMpToggle2(bool enabled)
 	{
 		Buffer ret;
-		ret.push_back(static_cast<unsigned char>(COMMAND_TYPE::MULTIPOINT_ENABLE_SET_2));
+		ret.push_back(static_cast<uint8_t>(COMMAND_TYPE::MULTIPOINT_ENABLE_SET_2));
 		ret.push_back(0x00);
 		ret.push_back(0x07);
 		ret.push_back(0x01);
@@ -226,7 +226,7 @@ namespace CommandSerializer
 	Buffer serializeSpeakToChatEnabled(bool enabled)
 	{
 		Buffer ret;
-		ret.push_back(static_cast<unsigned char>(COMMAND_TYPE::AUTOMATIC_POWER_OFF_BUTTON_MODE_SET));
+		ret.push_back(static_cast<uint8_t>(COMMAND_TYPE::AUTOMATIC_POWER_OFF_BUTTON_MODE_SET));
 		ret.push_back(0x0c);
 		ret.push_back(!enabled);
 		ret.push_back(0x01);
@@ -234,13 +234,14 @@ namespace CommandSerializer
 	}
 
 	// from https://github.com/Freeyourgadget/Gadgetbridge/blob/master/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/sony/headphones/protocol/impl/v3/SonyProtocolImplV3.java
-	Buffer serializeEqualizerSetting(char bass, std::vector<int> const& bands)
+	//      https://github.com/Plutoberth/SonyHeadphonesClient/commit/66d8e52aad4ffd08aa78e811a23f67a5bad07d9a
+	Buffer serializeEqualizerSetting(uint8_t preset, char bass, std::vector<int> const& bands)
 	{
 		Buffer ret;
-		ret.push_back(static_cast<unsigned char>(COMMAND_TYPE::EQUALIZER_SET));
+		ret.push_back(static_cast<uint8_t>(COMMAND_TYPE::EQUALIZER_SET));
 		ret.push_back(0x00);
-		ret.push_back(0xa0);
-		ret.push_back(0x06);
+		ret.push_back(preset);
+		ret.push_back(0x06); // data size
 		ret.push_back(bass + 10);
 		ret.push_back(bands[0] + 10);
 		ret.push_back(bands[1] + 10);
@@ -249,20 +250,29 @@ namespace CommandSerializer
 		ret.push_back(bands[4] + 10);
 		return ret;
 	}
+	Buffer serializeEqualizerSetting(uint8_t preset)
+	{
+		Buffer ret;
+		ret.push_back(static_cast<uint8_t>(COMMAND_TYPE::EQUALIZER_SET));
+		ret.push_back(0x00);
+		ret.push_back(preset);
+		ret.push_back(0x00); // data size		
+		return ret;
+	}
 	Buffer serializeTouchSensorAssignment(TOUCH_SENSOR_FUNCTION funcL, TOUCH_SENSOR_FUNCTION funcR)
 	{
 		Buffer ret;
-		ret.push_back(static_cast<unsigned char>(COMMAND_TYPE::AUTOMATIC_POWER_OFF_BUTTON_MODE_SET));
+		ret.push_back(static_cast<uint8_t>(COMMAND_TYPE::AUTOMATIC_POWER_OFF_BUTTON_MODE_SET));
 		ret.push_back(0x03);
 		ret.push_back(0x02);
-		ret.push_back(static_cast<unsigned char>(funcL));
-		ret.push_back(static_cast<unsigned char>(funcR));
+		ret.push_back(static_cast<uint8_t>(funcL));
+		ret.push_back(static_cast<uint8_t>(funcR));
 		return ret;
 	}
 	Buffer serializeOnCallVoiceCaptureSetting(bool enabled)
 	{
 		Buffer ret;
-		ret.push_back(static_cast<unsigned char>(COMMAND_TYPE::MULTIPOINT_ETC_ENABLE_SET));
+		ret.push_back(static_cast<uint8_t>(COMMAND_TYPE::MULTIPOINT_ETC_ENABLE_SET));
 		ret.push_back(0xD1);
 		ret.push_back(0x00);
 		ret.push_back(!enabled);

--- a/Client/src/CommandSerializer.h
+++ b/Client/src/CommandSerializer.h
@@ -17,7 +17,7 @@ namespace CommandSerializer
 
 	Buffer _escapeSpecials(const Buffer& src);
 	Buffer _unescapeSpecials(const Buffer& src);
-	unsigned char _sumChecksum(const char* src, size_t size);
+	unsigned char _sumChecksum(const unsigned char* src, size_t size);
 	unsigned char _sumChecksum(const Buffer& src);
 	//Package a serialized command according to the protocol
 	/*
@@ -40,7 +40,8 @@ namespace CommandSerializer
 	Buffer serializeMpToggle(bool enabled);
 	Buffer serializeSpeakToChatConfig(char sensitivity, char timeout);
 	Buffer serializeSpeakToChatEnabled(bool enabled);
-	Buffer serializeEqualizerSetting(char bass, std::vector<int> const& bands);
+	Buffer serializeEqualizerSetting(unsigned char preset, char bass, std::vector<int> const& bands);
+	Buffer serializeEqualizerSetting(unsigned char preset);
 	Buffer serializeTouchSensorAssignment(TOUCH_SENSOR_FUNCTION funcL, TOUCH_SENSOR_FUNCTION funcR);
 	Buffer serializeOnCallVoiceCaptureSetting(bool enabled);
 	// POD Wrapper for any Buffer (of messages) that contains the command payload (which may also be size 0,i.e. ACKs)
@@ -67,7 +68,7 @@ namespace CommandSerializer
 
 		inline Buffer::const_iterator begin() const { return messageBytes.begin() + 7; }
 		inline Buffer::const_iterator end() const { return begin() + getSize(); }
-		inline const char operator[](int i) const { return *(begin() + i); }
+		inline const Buffer::value_type operator[](int i) const { return *(begin() + i); }
 
 		inline Buffer const& getMessage() const { return messageBytes; }
 

--- a/Client/src/Constants.h
+++ b/Client/src/Constants.h
@@ -2,6 +2,7 @@
 
 #include <vector>
 #include <ranges>
+#include <cstdint>
 
 inline constexpr auto MAX_BLUETOOTH_MESSAGE_SIZE = 2048;
 inline constexpr char START_MARKER{ 62 };
@@ -30,16 +31,16 @@ Profile Descriptor List:
  */
 
 inline constexpr auto SERVICE_UUID = "956C7B26-D49A-4BA8-B03F-B17D393CB6E2";
-inline unsigned char SERVICE_UUID_IN_BYTES[] = { // this is the SERVICE_UUID but in bytes
+inline uint8_t SERVICE_UUID_IN_BYTES[] = { // this is the SERVICE_UUID but in bytes
 		0x95, 0x6C, 0x7B, 0x26, 0xD4, 0x9A, 0x4B, 0xA8, 0xB0, 0x3F, 0xB1, 0x7D, 0x39, 0x3C, 0xB6, 0xE2
 };
 
 #define APP_NAME "Sony Headphones Client v" __HEADPHONES_APP_VERSION__
 #define APP_NAME_W (L"" APP_NAME)
 #define APP_CONFIG_NAME "sonyheadphonesclient.toml"
-using Buffer = std::vector<char>;
+using Buffer = std::vector<uint8_t>;
 
-enum class DATA_TYPE : signed char
+enum class DATA_TYPE : uint8_t
 {
 	DATA = 0,
 	ACK = 1,
@@ -57,29 +58,29 @@ enum class DATA_TYPE : signed char
 	SHOT_COMMON =  29,
 	SHOT_MDR_NO2 = 30,
 	LARGE_DATA_COMMON =  45,
-	UNKNOWN = -1
+	UNKNOWN = 0xff
 };
 
-enum class NC_ASM_EFFECT : signed char
+enum class NC_ASM_EFFECT : uint8_t
 {
 	OFF = 0,
 	ON = 1
 };
 
-enum class NC_ASM_SETTING_TYPE : signed char
+enum class NC_ASM_SETTING_TYPE : uint8_t
 {
 	NOISE_CANCELLING = 0,
 	AMBIENT_SOUND = 1
 };
 
-enum class ASM_ID : signed char
+enum class ASM_ID : uint8_t
 {
 	NORMAL = 0,
 	VOICE = 1
 };
 
 // https://github.com/Freeyourgadget/Gadgetbridge/blob/master/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/sony/headphones/protocol/impl/v1/PayloadTypeV1.java
-enum class COMMAND_TYPE : unsigned char
+enum class COMMAND_TYPE : uint8_t
 {
 	INIT_REQUEST = 0x00,
 	INIT_RESPONSE = 0x01,
@@ -153,7 +154,7 @@ enum class COMMAND_TYPE : unsigned char
 	UNKNOWN = 0xFF
 };
 
-enum class PLAYBACK_CONTROL : signed char
+enum class PLAYBACK_CONTROL : uint8_t
 {
 	NONE = 0,
 	PAUSE = 1,
@@ -162,17 +163,48 @@ enum class PLAYBACK_CONTROL : signed char
 	PLAY = 7
 };
 
-enum class PLAYBACK_CONTROL_RESPONSE : signed char
+enum class PLAYBACK_CONTROL_RESPONSE : uint8_t
 {
 	PLAY = 1,
 	PAUSE = 2
 };
 
-enum class TOUCH_SENSOR_FUNCTION : unsigned char
+enum class TOUCH_SENSOR_FUNCTION : uint8_t
 {
 	PLAYBACK_CONTROL = 0x20,
 	AMBIENT_NC_CONTROL = 0x35,
 	NOT_ASSIGNED = 0xff,
 	
 	NUM_FUNCTIONS = 3
+};
+
+// https://github.com/Plutoberth/SonyHeadphonesClient/commit/66d8e52aad4ffd08aa78e811a23f67a5bad07d9a
+enum class EQ_PRESET_ID: uint8_t {
+	OFF = 0,
+	ROCK = 1,
+	POP = 2,
+	JAZZ = 3,
+	DANCE = 4,
+	EDM = 5,
+	R_AND_B_HIP_HOP = 6,
+	ACOUSTIC = 7,
+	/*RESERVED_FOR_FUTURE_NO8 = 8,… */
+	/*RESERVED_FOR_FUTURE_NO15 = 15,*/
+	BRIGHT = 16,
+	EXCITED = 17,
+	MELLOW = 18,
+	RELAXED = 19,
+	VOCAL = 20,
+	TREBLE = 21,
+	BASS = 22,
+	SPEECH = 23,
+	/*RESERVED_FOR_FUTURE_NO24 = 24,… */
+	/*RESERVED_FOR_FUTURE_NO31 = 31,*/
+	CUSTOM = 0xa0,
+	USER_SETTING1 = 0xa1,
+	USER_SETTING2 = 0xa2,
+	USER_SETTING3 = 0xa3,
+	USER_SETTING4 = 0xa4,
+	USER_SETTING5 = 0xa5,
+	UNSPECIFIED = 0xff,
 };

--- a/Client/src/Headphones.cpp
+++ b/Client/src/Headphones.cpp
@@ -302,9 +302,9 @@ void Headphones::requestSync()
 void Headphones::recvAsync()
 {
     if (_conn.isConnected())
-        _recvFuture.setFromAsync([this]() -> std::optional<CommandSerializer::CommandMessage> {
+        _recvFuture.setFromAsync([this]() -> std::optional<HeadphonesMessage> {
             auto& conn = this->getConn();
-            CommandSerializer::CommandMessage cmd;
+            HeadphonesMessage cmd;
             conn.recvCommand(cmd);
             return cmd;
         });
@@ -337,286 +337,296 @@ void Headphones::requestPowerOff()
 	waitForAck();
 }
 
-HeadphonesEvent Headphones::_handleMessage(CommandSerializer::CommandMessage const& msg)
-{	
-	HeadphonesEvent event;
-	bool dirty = false;
-	switch (msg.getDataType())
-	{		
-		case DATA_TYPE::ACK:			
-			_ackCV.notify_one();
-			break;
-		case DATA_TYPE::DATA_MDR:
-		case DATA_TYPE::DATA_MDR_NO2:
-		{
-			auto cmd = static_cast<COMMAND_TYPE>(msg[0]);
-#if _DEBUG
-			std::cout << "[message] cmd: 0x" << std::hex << static_cast<int>(cmd) << '\n';
-#endif
-			switch (cmd)
-			{
-			case COMMAND_TYPE::INIT_RESPONSE:
-				hasInit = true;
-				break;
-			case COMMAND_TYPE::NCASM_PARAM_RET:
-			case COMMAND_TYPE::NCASM_PARAM_NOTIFY:
-				// see serializeNcAndAsmSetting
-				asmEnabled.overwrite(msg[3]);
-				asmFoucsOnVoice.overwrite(msg[5]);
-				if (msg[4])
-					asmLevel.overwrite(msg[6]);
-				else
-					asmLevel.overwrite(0);
-				break;
-			case COMMAND_TYPE::BATTERY_LEVEL_RET:
-				switch (msg[1])
-				{
-				case 1:
-					statBatteryL.overwrite(msg[2]);
-					statBatteryR.overwrite(msg[4]);
-					break;
-				case 2:
-					statBatteryCase.overwrite(msg[2]);
-					break;
-				default:
-					break;
-				}
-				break;
-			case COMMAND_TYPE::PLAYBACK_STATUS_RET:
-			case COMMAND_TYPE::PLAYBACK_STATUS_NOTIFY:
-			{
-				auto type = msg[1];
-				switch (type)
-				{
-				case 0x01:
-				{
-					event.type = HeadphonesEvent::PlaybackMetadataUpdate;
+HeadphonesEvent Headphones::_handleInitResponse(const HeadphonesMessage& msg) {
+    hasInit = true;
+    return HeadphonesEvent::Initialized;
+}
 
-					auto it = msg.begin() + 3;
-					auto type = *it;
-					auto len = *it++;
-					playback.title = std::string(it, it + len);
-					it += len;
-					type = *it++;
-					len = *it++;
-					playback.album = std::string(it, it + len);
-					it += len;
-					type = *it++;
-					len = *it++;
-					playback.artist = std::string(it, it + len);
-					break;
-				}
-				case 0x20:
-					event.type = HeadphonesEvent::PlaybackVolumeUpdate;
+HeadphonesEvent Headphones::_handleNcAsmParam(const HeadphonesMessage& msg) {
+    // see serializeNcAndAsmSetting
+    asmEnabled.overwrite(msg[3]);
+    asmFoucsOnVoice.overwrite(msg[5]);
+    if (msg[4])
+        asmLevel.overwrite(msg[6]);
+    else
+        asmLevel.overwrite(0);
+    return HeadphonesEvent::NcAsmParamUpdate;
+}
 
-					volume.overwrite(msg[2]);
-					break;
-				default:
-					dirty = true;
-					break;
-				}
-				break;
-			}
-			case COMMAND_TYPE::PLAYBACK_SND_PRESSURE_RET:
-				switch (msg[1]) {
-				case 0x03:
-					playback.sndPressure = msg[2];
-					break;
-				default:
-					dirty = true;
-					break;
-				}
-				break;
-			case COMMAND_TYPE::VOICEGUIDANCE_PARAM_RET:
-			case COMMAND_TYPE::VOICEGUIDANCE_PARAM_NOTIFY:
-				switch (msg[1])
-				{
-				case 0x20:					
-					miscVoiceGuidanceVol.overwrite(msg[2]);
-					break;
-				default:
-					dirty = true;
-					break;
-				}
-				break;
-			case COMMAND_TYPE::MULTIPOINT_DEVICE_RET:
-			case COMMAND_TYPE::MULTIPOINT_DEVICE_NOTIFY:
-				event.type = HeadphonesEvent::MultipointSwitch;
+HeadphonesEvent Headphones::_handleBatteryLevelRet(const HeadphonesMessage& msg) {
+    switch (msg[1]) {
+    case 1:
+        statBatteryL.overwrite(msg[2]);
+        statBatteryR.overwrite(msg[4]);
+        return HeadphonesEvent::BatteryLevelUpdate;
+    case 2:
+        statBatteryCase.overwrite(msg[2]);
+        return HeadphonesEvent::BatteryLevelUpdate;
+    default:
+        return HeadphonesEvent::MessageUnhandled;
+    }
+}
 
-				mpDeviceMac.overwrite(std::string(msg.begin() + 3, msg.end()));
-				break;
-			case COMMAND_TYPE::CONNECTED_DEVIECES_RET:
-			case COMMAND_TYPE::CONNECTED_DEVIECES_NOTIFY:
-			{
-				if (msg[3] == 0x00)
-					break;
+HeadphonesEvent Headphones::_handlePlaybackStatus(const HeadphonesMessage& msg) {
+    auto type = msg[1];
+    switch (type) {
+    case 0x01:
+    {
+		auto it = msg.begin() + 3;
+		auto type = *it;
+		auto len = *it++;
+		playback.title = std::string(it, it + len);
+		it += len;
+		type = *it++;
+		len = *it++;
+		playback.album = std::string(it, it + len);
+		it += len;
+		type = *it++;
+		len = *it++;
+		playback.artist = std::string(it, it + len);
+        return HeadphonesEvent::PlaybackMetadataUpdate;
+    }
+    case 0x20:        
+        volume.overwrite(msg[2]);
+        return HeadphonesEvent::PlaybackVolumeUpdate;
+    default:
+        return HeadphonesEvent::MessageUnhandled;
+    }
+}
 
-				event.type = HeadphonesEvent::ConnectedDeviceUpdate;
+HeadphonesEvent Headphones::_handlePlaybackSndPressureRet(const HeadphonesMessage& msg) {
+    switch (msg[1]) {
+    case 0x03:
+        playback.sndPressure = msg[2];
+        return HeadphonesEvent::SoundPressureUpdate;
+    default:
+        return HeadphonesEvent::MessageUnhandled;
+    }
+}
 
-				connectedDevices.clear();
-				pairedDevices.clear();
+HeadphonesEvent Headphones::_handleVoiceGuidanceParam(const HeadphonesMessage& msg) {
+    switch (msg[1]) {
+    case 0x20:
+        miscVoiceGuidanceVol.overwrite(msg[2]);
+        return HeadphonesEvent::VoiceGuidanceVolumeUpdate;
+    default:
+        return HeadphonesEvent::MessageUnhandled;
+    }
+}
 
-				int total = msg[1];
-				int connected = msg[2];
-				auto it = msg.begin() + 3;
-				for (int i = 0; i < total; i++)
-				{
-					auto mac = std::string(it, it + 6 * 3 - 1);
-					it += 6 * 3 - 1;
-					char unk0 = *it++;
-					char unk1 = *it++;
-					char unk2 = *it++;
-					char unk3 = *it++;
-					auto len = *it++;					
-					auto name = std::string(it, it + len);	
-					it += len;
-					if (i < connected)
-						connectedDevices[mac] = BluetoothDevice(name, mac);
-					else
-						pairedDevices[mac] = BluetoothDevice(name, mac);
-				}
-			}
-				break;
-			case COMMAND_TYPE::PLAYBACK_STATUS_CONTROL_RET:
-			case COMMAND_TYPE::PLAYBACK_STATUS_CONTROL_NOTIFY:
-			{
-				event.type = HeadphonesEvent::PlaybackPlayPauseUpdate;
+HeadphonesEvent Headphones::_handleMultipointDevice(const HeadphonesMessage& msg) {    
+    mpDeviceMac.overwrite(std::string(msg.begin() + 3, msg.end()));
+    return HeadphonesEvent::MultipointDeviceSwitchUpdate;
+}
 
-				switch (static_cast<PLAYBACK_CONTROL_RESPONSE>(msg[3]))
-				{
-					case PLAYBACK_CONTROL_RESPONSE::PLAY:
-						playPause.overwrite(true);
-						break;
-					case PLAYBACK_CONTROL_RESPONSE::PAUSE:
-						playPause.overwrite(false);
-						break;
-					default:
-						break;
-				}
-				break;
-			}
-				break;
-			case COMMAND_TYPE::MULTIPOINT_ETC_ENABLE_RET:
-			case COMMAND_TYPE::MULTIPOINT_ETC_ENABLE_NOITIFY:
-			{
-				int sub = static_cast<int>(msg[1]) & 0xff;
-				switch (sub)
-				{
-				case 0xD1:
-					voiceCapEnabled.overwrite(!(bool)msg[3]);
-					break;
-				case 0xD2:
-					mpEnabled.overwrite(!(bool)msg[3]);
-					break;
-				default:
-					break;
-				}
-				break;
-			}
-			case COMMAND_TYPE::AUTOMATIC_POWER_OFF_BUTTON_MODE_NOTIFY:
-			case COMMAND_TYPE::AUTOMATIC_POWER_OFF_BUTTON_MODE_RET:
-				switch (msg[1])
-				{
-				case 0x0c:
-					stcEnabled.overwrite(!(bool)msg[2]);
-					break;
-				case 0x03:
-					touchLeftFunc.overwrite(static_cast<TOUCH_SENSOR_FUNCTION>(msg[3]));
-					touchRightFunc.overwrite(static_cast<TOUCH_SENSOR_FUNCTION>(msg[4]));
-					break;
-				default:
-					dirty = true;
-					break;
-				}
-				break;
-			case COMMAND_TYPE::SPEAK_TO_CHAT_RET:
-			case COMMAND_TYPE::SPEAK_TO_CHAT_NOTIFY:
-				switch (msg[1])
-				{
-				case 0x0c:
-					stcLevel.overwrite(msg[2]);
-					stcTime.overwrite(msg[3]);
-					break;
-				default:
-					dirty = true;
-					break;
-				}
-				break;
-			case COMMAND_TYPE::EQUALIZER_RET:
-			case COMMAND_TYPE::EQUALIZER_NOTIFY:
-				// [RET/NOTIFY 00 a2 06] 0a/bass 0a/band1 0a/band2 0a/band3 0a/band4 0a/band5
-				// values have +10 offset
-				switch (msg[3])
-				{
-				case 0x06:
-					eqConfig.overwrite(EqualizerConfig(
-						msg[4] - 10,
-						std::vector<int>{ 
-							msg[5] - 10,
-							msg[6] - 10,
-							msg[7] - 10, 
-							msg[8] - 10,
-							msg[9] - 10,
-						}
-					));
-					break;
-				default:
-					break;
-				}
-				break;
-			case COMMAND_TYPE::MISC_DATA_RET:
-			{				
-				// NOTE: Plain text data in either JSON or button names(?)
-				switch (msg[1])
-				{
-				case 0x01:
-				{
-					// NOTE: These seems to always contain button names and are null terminated							
-					auto it = msg.begin();
-					int len = 0;
-					if (msg[2]) len = msg[2], it = msg.begin() + 3; // key...
-					else len = msg[3], it = msg.begin() + 4; // op...
-					event.type = HeadphonesEvent::HeadphoneInteractionEvent;
-					event.message = std::string(it, it + len);
-				}
-				break;
-				case 0x00:
-				{
-					// NOTE: These are sent immediately after MISC_DATA_GET 0x01
-					// and won't be sent preiodically afterwards
-					// NOTE: These seem to always conatin JSON data
-					std::string str(msg.begin() + 4, msg.end());
-					event.type = HeadphonesEvent::JSONMessage;
-					event.message = str;
-					std::cout << "[message] " << str << '\n';
-				}
-				break;
-				default:
-					dirty = true;
-				}
-				break;
-			}
-			default:
-				dirty = true;
-				break;
-			}
-			_conn.sendAck(msg.getSeqNumber());
-			break;
-		}
-		default:
-			dirty = true;
-	}
-	if (dirty) {
-		std::cout << "[message] message not handled. \n";
-		std::cout << "[message] type: " << static_cast<int>(msg.getDataType()) << '\n';
-		std::cout << "[message] (hex) \n";
-		for (int byte : msg) std::cout << std::setfill('0') << std::setw(2) << std::hex << (byte & 0xff) << ' ';
-		std::cout << '\n';
-		std::cout << "[message] (plaintext) \n";
-		for (char c : msg) std::cout << c;
-		std::cout << '\n';
-	}
-	return event;
+HeadphonesEvent Headphones::_handleConnectedDevices(const HeadphonesMessage& msg) {
+    if (msg[3] == 0x00)
+        return HeadphonesEvent::NoChange;
+
+    connectedDevices.clear();
+    pairedDevices.clear();
+
+    int total = msg[1];
+    int connected = msg[2];
+    auto it = msg.begin() + 3;
+    for (int i = 0; i < total; i++) {
+        auto mac = std::string(it, it + (6 * 3 - 1));
+        it += (6 * 3 - 1);
+        char unk0 = *it++;
+        char unk1 = *it++;
+        char unk2 = *it++;
+        char unk3 = *it++;
+        auto len = *it++;
+        auto name = std::string(it, it + len);
+        it += len;
+        if (i < connected)
+            connectedDevices[mac] = BluetoothDevice(name, mac);
+        else
+            pairedDevices[mac] = BluetoothDevice(name, mac);
+    }
+    return HeadphonesEvent::ConnectedDeviceUpdate;
+}
+
+HeadphonesEvent Headphones::_handlePlaybackStatusControl(const HeadphonesMessage& msg) {    
+    switch (static_cast<PLAYBACK_CONTROL_RESPONSE>(msg[3])) {
+    case PLAYBACK_CONTROL_RESPONSE::PLAY:
+        playPause.overwrite(true);
+        return HeadphonesEvent::PlaybackPlayPauseUpdate;
+    case PLAYBACK_CONTROL_RESPONSE::PAUSE:
+        playPause.overwrite(false);
+        return HeadphonesEvent::PlaybackPlayPauseUpdate;
+    default:
+        return HeadphonesEvent::MessageUnhandled;
+    }
+}
+
+HeadphonesEvent Headphones::_handleMultipointEtcEnable(const HeadphonesMessage& msg) {
+    int sub = static_cast<int>(msg[1]) & 0xff;
+    switch (sub) {
+    case 0xD1:
+        voiceCapEnabled.overwrite(!(bool)msg[3]);
+        return HeadphonesEvent::VoiceCaptureEnabledUpdate;
+    case 0xD2:
+        mpEnabled.overwrite(!(bool)msg[3]);
+        return HeadphonesEvent::MultipointEnabledUpdate;
+    default:
+        return HeadphonesEvent::MessageUnhandled;
+    }
+}
+
+HeadphonesEvent Headphones::_handleAutomaticPowerOffButtonMode(const HeadphonesMessage& msg) {
+    switch (msg[1]) {
+    case 0x0c:
+        stcEnabled.overwrite(!(bool)msg[2]);
+        return HeadphonesEvent::SpeakToChatEnabledUpdate;
+    case 0x03:
+        touchLeftFunc.overwrite(static_cast<TOUCH_SENSOR_FUNCTION>(msg[3]));
+        touchRightFunc.overwrite(static_cast<TOUCH_SENSOR_FUNCTION>(msg[4]));
+        return HeadphonesEvent::TouchFunctionUpdate;
+    default:
+        return HeadphonesEvent::MessageUnhandled;
+    }
+}
+
+HeadphonesEvent Headphones::_handleSpeakToChat(const HeadphonesMessage& msg) {
+    switch (msg[1]) {
+    case 0x0c:
+        stcLevel.overwrite(msg[2]);
+        stcTime.overwrite(msg[3]);
+        return HeadphonesEvent::SpeakToChatParamUpdate;
+    default:
+        return HeadphonesEvent::MessageUnhandled;
+    }
+}
+
+HeadphonesEvent Headphones::_handleEqualizer(const HeadphonesMessage& msg) {
+    // [RET/NOTIFY 00 a2 06] 0a/bass 0a/band1 0a/band2 0a/band3 0a/band4 0a/band5
+    // values have +10 offset
+    switch (msg[3]) {
+    case 0x06:
+        eqConfig.overwrite(EqualizerConfig(
+            msg[4] - 10,
+            std::vector<int>{
+                msg[5] - 10,
+                msg[6] - 10,
+                msg[7] - 10,
+                msg[8] - 10,
+                msg[9] - 10,
+            }
+        ));
+        return HeadphonesEvent::EqualizerParamUpdate;
+    default:
+        return HeadphonesEvent::MessageUnhandled;
+    }
+}
+
+HeadphonesEvent Headphones::_handleMiscDataRet(const HeadphonesMessage& msg) {
+    // NOTE: Plain text data in either JSON or button names(?)
+    switch (msg[1]) {
+    case 0x01:
+    {
+        // NOTE: These seems to always contain button names and are null terminated
+        auto it = msg.begin();
+        int len = 0;
+        if (msg[2]) len = msg[2], it = msg.begin() + 3; // key...
+        else len = msg[3], it = msg.begin() + 4; // op...        
+        interactionMessage.overwrite(std::string(it, it + len));
+        return HeadphonesEvent::InteractionUpdate;
+    }
+    case 0x00:
+    {
+        // NOTE: These are sent immediately after MISC_DATA_GET 0x01
+        // and won't be sent preiodically afterwards
+        // NOTE: These seem to always conatin JSON data
+        std::string str(msg.begin() + 4, msg.end());
+        deviceMessages.overwrite(str);        
+        return HeadphonesEvent::JSONMessage;
+    }
+    default:
+        return HeadphonesEvent::MessageUnhandled;
+    }
+}
+
+HeadphonesEvent Headphones::_handleMessage(HeadphonesMessage const& msg)
+{		
+	HeadphonesEvent result {};
+	DATA_TYPE data_type = msg.getDataType();
+	rawMessage.overwrite(msg);
+    switch (data_type)
+    {
+    case DATA_TYPE::ACK:
+        _ackCV.notify_one();
+        return HeadphonesEvent::NoChange;
+    case DATA_TYPE::DATA_MDR:
+    case DATA_TYPE::DATA_MDR_NO2:
+    {
+        COMMAND_TYPE command = static_cast<COMMAND_TYPE>(msg[0]);
+        switch (command)
+        {
+        case COMMAND_TYPE::INIT_RESPONSE:
+            result = _handleInitResponse(msg);
+            break;
+        case COMMAND_TYPE::NCASM_PARAM_RET:
+        case COMMAND_TYPE::NCASM_PARAM_NOTIFY:
+            result = _handleNcAsmParam(msg);
+            break;
+        case COMMAND_TYPE::BATTERY_LEVEL_RET:
+            result = _handleBatteryLevelRet(msg);
+            break;
+        case COMMAND_TYPE::PLAYBACK_STATUS_RET:
+        case COMMAND_TYPE::PLAYBACK_STATUS_NOTIFY:
+            result = _handlePlaybackStatus(msg);
+            break;
+        case COMMAND_TYPE::PLAYBACK_SND_PRESSURE_RET:
+            result = _handlePlaybackSndPressureRet(msg);
+            break;
+        case COMMAND_TYPE::VOICEGUIDANCE_PARAM_RET:
+        case COMMAND_TYPE::VOICEGUIDANCE_PARAM_NOTIFY:
+            result = _handleVoiceGuidanceParam(msg);
+            break;
+        case COMMAND_TYPE::MULTIPOINT_DEVICE_RET:
+        case COMMAND_TYPE::MULTIPOINT_DEVICE_NOTIFY:
+            result = _handleMultipointDevice(msg);
+            break;
+        case COMMAND_TYPE::CONNECTED_DEVIECES_RET:
+        case COMMAND_TYPE::CONNECTED_DEVIECES_NOTIFY:
+            result = _handleConnectedDevices(msg);
+            break;
+        case COMMAND_TYPE::PLAYBACK_STATUS_CONTROL_RET:
+        case COMMAND_TYPE::PLAYBACK_STATUS_CONTROL_NOTIFY:
+            result = _handlePlaybackStatusControl(msg);
+            break;
+        case COMMAND_TYPE::MULTIPOINT_ETC_ENABLE_RET:
+        case COMMAND_TYPE::MULTIPOINT_ETC_ENABLE_NOITIFY:
+            result = _handleMultipointEtcEnable(msg);
+            break;
+        case COMMAND_TYPE::AUTOMATIC_POWER_OFF_BUTTON_MODE_NOTIFY:
+        case COMMAND_TYPE::AUTOMATIC_POWER_OFF_BUTTON_MODE_RET:
+            result = _handleAutomaticPowerOffButtonMode(msg);
+            break;
+        case COMMAND_TYPE::SPEAK_TO_CHAT_RET:
+        case COMMAND_TYPE::SPEAK_TO_CHAT_NOTIFY:
+            result = _handleSpeakToChat(msg);
+            break;
+        case COMMAND_TYPE::EQUALIZER_RET:
+        case COMMAND_TYPE::EQUALIZER_NOTIFY:
+            result = _handleEqualizer(msg);
+            break;
+        case COMMAND_TYPE::MISC_DATA_RET:
+            result = _handleMiscDataRet(msg);
+            break;
+        default:
+            // Command type not recognized
+            break;
+        }
+        _conn.sendAck(msg.getSeqNumber());
+        break;
+    }
+    default:
+        // Data type not recognized
+		break;
+    }
+	return result;
 }
 
 HeadphonesEvent Headphones::poll()
@@ -628,7 +638,7 @@ HeadphonesEvent Headphones::poll()
 			return _handleMessage(cmd.value());
 		}
 	}
-	return {};
+	return HeadphonesEvent::NoMessage;
 }
 
 void Headphones::disconnect()

--- a/Client/src/Headphones.h
+++ b/Client/src/Headphones.h
@@ -6,65 +6,106 @@
 #include <iostream>
 #include <map>
 #include <variant>
-struct HeadphonesEvent {
-	enum EventType {
-		None,
-
-		JSONMessage,
-		HeadphoneInteractionEvent,
-
-		PlaybackMetadataUpdate,
-		PlaybackVolumeUpdate,
-		PlaybackPlayPauseUpdate,
-
-		MultipointSwitch,
-
-		ConnectedDeviceUpdate,
-
-	} type;
-	std::variant<std::string> message;
-
-	HeadphonesEvent() : type(None) {};
-	HeadphonesEvent(EventType type) : type(type) {};
-	HeadphonesEvent(EventType type, auto const& message) : type(type), message(message) {};
-	~HeadphonesEvent() {};
-};
-
 template <class T>
-struct Property {
+struct Property
+{
 	T current;
 	T desired;
 
 	bool pendingRequest = false;
 
-	void flagPending();
-	bool isPending();
+	void flagPending()
+	{
+		this->pendingRequest = true;
+	};
+	bool isPending()
+	{
+		return this->pendingRequest;
+	};
 
-	void fulfill();
-	bool isFulfilled();
-	void overwrite(T const& value);
+	void fulfill()
+	{
+		this->current = this->desired;
+		this->pendingRequest = false;
+	};
+	bool isFulfilled()
+	{
+		return this->desired == this->current;
+	};
+	void overwrite(T const &value)
+	{
+		current = value;
+		desired = value;
+		this->pendingRequest = false;
+	};
 };
 
 template <class T>
-struct ReadonlyProperty {
+struct ReadonlyProperty
+{
 	T current;
-
-	void overwrite(T const& value);
+	
+	void overwrite(T const &value)
+	{
+		current = value;
+	};
 };
+enum class HeadphonesEvent
+{
+	MessageUnhandled = -1,
+	
+	NoMessage,	
+	NoChange,
+	
+	JSONMessage,
+	Initialized,
 
-class Headphones {
+	NcAsmParamUpdate,
+	BatteryLevelUpdate,
+
+	PlaybackMetadataUpdate,
+	PlaybackVolumeUpdate,
+
+	SoundPressureUpdate,
+	VoiceGuidanceVolumeUpdate,
+	VoiceCaptureEnabledUpdate,
+
+	SpeakToChatParamUpdate,
+	SpeakToChatEnabledUpdate,
+	TouchFunctionUpdate,
+
+	PlaybackMetadataUpdate,
+	PlaybackVolumeUpdate,
+	PlaybackPlayPauseUpdate,
+
+	EqualizerParamUpdate,
+
+	MultipointDeviceSwitchUpdate,
+	MultipointEnabledUpdate,
+
+	ConnectedDeviceUpdate,
+
+	InteractionUpdate,
+};
+using HeadphonesMessage = CommandSerializer::CommandMessage;
+class Headphones
+{
 public:
 	/* The built-in EQ. All values should integers of range -10~+10 */
-	struct EqualizerConfig {
+	struct EqualizerConfig
+	{
 		int bassLevel{};
 		std::vector<int> bands;
 		EqualizerConfig() : bassLevel(0), bands(5) {};
-		EqualizerConfig(int bass, std::vector<int> const& bands) : bassLevel(bass), bands(bands) {};
-		bool operator==(EqualizerConfig const& other) const {
+		EqualizerConfig(int bass, std::vector<int> const &bands) : bassLevel(bass), bands(bands) {};
+		bool operator==(EqualizerConfig const &other) const
+		{
 			return bassLevel == other.bassLevel && bands == other.bands;
 		}
 	};
-	Headphones(BluetoothWrapper& conn);
+	Headphones(BluetoothWrapper &conn);
+
+	ReadonlyProperty<HeadphonesMessage> rawMessage;
 
 	// Is NC & Ambient sound enabled?
 	Property<bool> asmEnabled{};
@@ -88,6 +129,12 @@ public:
 	// Play/Pause. true for play, false for pause
 	ReadonlyProperty<bool> playPause{};
 
+	// Plaintext messages
+	ReadonlyProperty<std::string> deviceMessages{};
+	
+	// Headphone interaction message. Avalialbe after InteractionUpdate
+	ReadonlyProperty<std::string> interactionMessage{};
+
 	// Connected devices
 	std::map<std::string, BluetoothDevice> connectedDevices;
 
@@ -101,7 +148,8 @@ public:
 	Property<bool> voiceCapEnabled{};
 
 	// Playback
-	struct {
+	struct
+	{
 		std::string title;
 		std::string album;
 		std::string artist;
@@ -133,12 +181,12 @@ public:
 
 	void requestInit();
 	void requestSync();
-	void requestMultipointSwitch(const char* macString);
+	void requestMultipointSwitch(const char *macString);
 	void requestPlaybackControl(PLAYBACK_CONTROL control);
 	void requestPowerOff();
 
 	void recvAsync();
-	BluetoothWrapper& getConn() { return _conn; }
+	BluetoothWrapper &getConn() { return _conn; }
 
 	/*
 	Asynchornously poll for incoming messages and (optionally) returns any event
@@ -151,58 +199,31 @@ public:
 
 	~Headphones();
 
-	SingleInstanceFuture<std::optional<CommandSerializer::CommandMessage>> _recvFuture;
+	SingleInstanceFuture<std::optional<HeadphonesMessage>> _recvFuture;
 	SingleInstanceFuture<void> _sendCommandFuture;
 	SingleInstanceFuture<void> _requestFuture;
 
 private:
 	std::mutex _propertyMtx, _ackMtx;
-	BluetoothWrapper& _conn;
+	BluetoothWrapper &_conn;
 	std::condition_variable _ackCV;
 
-
-	HeadphonesEvent _handleMessage(CommandSerializer::CommandMessage const& msg);
+	// Helper functions for _handleMessage
+	HeadphonesEvent _handleInitResponse(const HeadphonesMessage &msg);
+	HeadphonesEvent _handleNcAsmParam(const HeadphonesMessage &msg);
+	HeadphonesEvent _handleBatteryLevelRet(const HeadphonesMessage &msg);
+	HeadphonesEvent _handlePlaybackStatus(const HeadphonesMessage &msg);
+	HeadphonesEvent _handlePlaybackSndPressureRet(const HeadphonesMessage &msg);
+	HeadphonesEvent _handleVoiceGuidanceParam(const HeadphonesMessage &msg);
+	HeadphonesEvent _handleMultipointDevice(const HeadphonesMessage &msg);
+	HeadphonesEvent _handleConnectedDevices(const HeadphonesMessage &msg);
+	HeadphonesEvent _handlePlaybackStatusControl(const HeadphonesMessage &msg);
+	HeadphonesEvent _handleMultipointEtcEnable(const HeadphonesMessage &msg);
+	HeadphonesEvent _handleAutomaticPowerOffButtonMode(const HeadphonesMessage &msg);
+	HeadphonesEvent _handleSpeakToChat(const HeadphonesMessage &msg);
+	HeadphonesEvent _handleEqualizer(const HeadphonesMessage &msg);
+	HeadphonesEvent _handleMiscDataRet(const HeadphonesMessage &msg);
+	HeadphonesEvent _handleMessage(HeadphonesMessage const &msg);
 
 	bool hasInit = false;
 };
-
-template<class T>
-inline void Property<T>::flagPending()
-{
-	this->pendingRequest = true;
-}
-
-
-template<class T>
-inline bool Property<T>::isPending()
-{
-	return this->pendingRequest;
-}
-
-
-template<class T>
-inline void Property<T>::fulfill()
-{
-	this->current = this->desired;
-	this->pendingRequest = false;
-}
-
-template<class T>
-inline bool Property<T>::isFulfilled()
-{
-	return this->desired == this->current;
-}
-
-template<class T>
-inline void Property<T>::overwrite(T const& value)
-{
-	current = value;
-	desired = value;
-	this->pendingRequest = false;
-}
-
-template<class T>
-inline void ReadonlyProperty<T>::overwrite(T const& value)
-{
-	current = value;
-}

--- a/Client/src/Headphones.h
+++ b/Client/src/Headphones.h
@@ -65,6 +65,7 @@ enum class HeadphonesEvent
 
 	PlaybackMetadataUpdate,
 	PlaybackVolumeUpdate,
+	PlaybackPlayPauseUpdate,
 
 	SoundPressureUpdate,
 	VoiceGuidanceVolumeUpdate,
@@ -73,10 +74,6 @@ enum class HeadphonesEvent
 	SpeakToChatParamUpdate,
 	SpeakToChatEnabledUpdate,
 	TouchFunctionUpdate,
-
-	PlaybackMetadataUpdate,
-	PlaybackVolumeUpdate,
-	PlaybackPlayPauseUpdate,
 
 	EqualizerParamUpdate,
 
@@ -169,6 +166,7 @@ public:
 	Property<int> stcTime{};
 
 	// Equalizer
+	Property<int> eqPreset;
 	Property<EqualizerConfig> eqConfig;
 
 	// Touch sensor function


### PR DESCRIPTION
This PR implements EQ preset switcher, initally brought up by https://github.com/mos9527/SonyHeadphonesClient/issues/9

Behaviour wise, once a EQ preset is selected, the app will ask for a updated EQ params for that selection. This is the same as the Sound Connect app.

Note that only the `Custom` and `Uset Setting N` selections have modifiable EQ parameters. Changing the parameter in other presets would result in the **default** parameter for those presets being applied to the `Custom` preset, and the changes will carry over to that instead. This is not enforced by the app, but rather by the headphone itself.

**Note:** Some preset IDs (borrowed from https://github.com/Plutoberth/SonyHeadphonesClient/pull/66) seem to be absent in the latest WF-1000XM5 firmware. Selecting, for example, the `Jazz` preset has no effect. Most seem to work, however.