### PR TITLE
Fix building with -Werror=format-security

### DIFF
--- a/src/App.cpp
+++ b/src/App.cpp
@@ -392,7 +392,7 @@ void App::_drawControls()
                     const auto draw_touch_sensor_combo = [&](auto& prop, const char* label) {
                         auto it = TOUCH_SENSOR_FUNCTION_STR.lower_bound({prop.desired});
                         if (it == TOUCH_SENSOR_FUNCTION_STR.end() || it->first != prop.desired)  {
-                            ImGui::Text(label);
+                            ImGui::TextUnformatted(label);
                             ImGui::SameLine();
                             ImGui::Text("Unknown Function: %d", static_cast<int>(prop.desired));
                             return;


### PR DESCRIPTION
```builder
/build/source/src/App.cpp: In instantiation of 'App::_drawControls()::<lambda(auto:49&, const char*)> [with auto:49 = Property<TOUCH_SENSOR_FUNCTION>]':
       > /build/source/src/App.cpp:413:44:   required from here
       >   413 |                     draw_touch_sensor_combo(_headphones->touchLeftFunc, "Left Touch Sensor");
       >       |                     ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       > /build/source/src/App.cpp:395:40: error: format not a string literal and no format arguments [-Werror=format-security]
       >   395 |                             ImGui::Text(label);
       >       |                             ~~~~~~~~~~~^~~~~~~
       > /build/source/src/App.cpp: In member function 'void App::_handleHeadphoneInteraction(const std::string&)':
       > /build/source/src/App.cpp:516:15: warning: ignoring return value of 'int system(const char*)' declared with attribute 'warn_unused_result' [-Wunused-result]
       >   516 |         system(cmd->second.c_str());
       >       |         ~~~~~~^~~~~~~~~~~~~~~~~~~~~
       > cc1plus: some warnings being treated as errors
       > make[2]: *** [CMakeFiles/SonyHeadphonesClient.dir/build.make:107: CMakeFiles/SonyHeadphonesClient.dir/src/App.cpp.o] Error 1
       > make[2]: *** Waiting for unfinished jobs....
       > make[1]: *** [CMakeFiles/Makefile2:153: CMakeFiles/SonyHeadphonesClient.dir/all] Error 2
       > make: *** [Makefile:136: all] Error 2
```