### PR TITLE
Fix GCC 13 build failures

### DIFF
--- a/client/Client.cpp
+++ b/client/Client.cpp
@@ -498,7 +498,7 @@ void DrawDeviceDiscovery()
     {
         static MDRDeviceInfo* pDeviceInfo = nullptr;
         static int nDeviceInfo = 0;
-        Span devices{pDeviceInfo, pDeviceInfo + nDeviceInfo};
+        Span<MDRDeviceInfo> devices{pDeviceInfo, static_cast<size_t>(nDeviceInfo)};
         ImGui::PushFont(nullptr, ImGui::GetContentRegionAvail().x * 0.05f);
         ImTextCentered("SonyHeadphonesClient");
         ImGui::PopFont();
@@ -623,7 +623,7 @@ void DrawDeviceControlsHeader()
         {
             *(badgeLast++) = {FormatEnum(gDevice.mUpscalingType), ~0u, ~0u};
         }
-        Span badges{badgeFirst, badgeLast};
+        Span<Badge> badges{badgeFirst, static_cast<size_t>(badgeLast - badgeFirst)};
         // Right-align and draw them
         // XXX: This is surprisingly painful to do.
         ImVec2 padding = style.FramePadding;

--- a/libmdr/src/Command.cpp
+++ b/libmdr/src/Command.cpp
@@ -112,11 +112,12 @@ namespace mdr
         command = command.subspan(2);
         // Big-endian in
         Int32BE outSize = command[0] << 24u | command[1] << 16u | command[2] << 8u | command[3];
-        Span data = command.subspan(4);
+        Span<const UInt8> data = command.subspan(4);
         // Data...,checksum
         UInt8 checksum = data.back();
         // Checksum incl. type,seq,data
-        Span checkData = Span(unescaped).subspan(0, unescaped.size() - 1);
+        Span<const UInt8> checkData{unescaped.data(), unescaped.size()};
+        checkData = checkData.subspan(0, unescaped.size() - 1);
         UInt8 curChecksum = Checksum(checkData);
         if (checksum != curChecksum)
             return MDRUnpackResult::BAD_CHECKSUM;


### PR DESCRIPTION
I had build failures locally on GCC 13, they seem to have been caused by ambiguous std::span template argument deduction.

The fix is to replace some places with implicit Span construction to use explicit element types and pointer+length initialization, which resolves the ambiguity.