### PR TITLE
Add 0x30-family EQ presets to the UI (fixes EQ on WH-1000XM6 FW 2.x)

### DIFF
--- a/client/Client.cpp
+++ b/client/Client.cpp
@@ -164,6 +164,22 @@ const char* FormatEnum(v2::t1::EqPresetId id)
         return "Bass";
     case SPEECH:
         return "Speech";
+    case HEAVY:
+        return "Heavy";
+    case CLEAR:
+        return "Clear";
+    case HARD:
+        return "Hard";
+    case SOFT:
+        return "Soft";
+    case GAMING_EQ:
+        return "Gaming";
+    case FPS_1:
+        return "FPS 1";
+    case FPS_2:
+        return "FPS 2";
+    case FPS_3:
+        return "FPS 3";
     case CUSTOM:
         return "Custom";
     case USER_SETTING1:
@@ -989,6 +1005,7 @@ void DrawDeviceControlsSound()
         constexpr v2::t1::EqPresetId kSelections[] = {
             OFF, ROCK, POP, JAZZ, DANCE, EDM, R_AND_B_HIP_HOP, ACOUSTIC, BRIGHT, EXCITED,
             MELLOW, RELAXED, VOCAL, TREBLE, BASS, SPEECH,
+            HEAVY, CLEAR, HARD, SOFT, GAMING_EQ, FPS_1, FPS_2, FPS_3,
             CUSTOM, USER_SETTING1, USER_SETTING2, USER_SETTING3, USER_SETTING4, USER_SETTING5
         };
         ImComboBoxItems<v2::t1::EqPresetId>("Preset", kSelections, gDevice.mEqPresetId.desired);


### PR DESCRIPTION
WH-1000XM6 firmware 2.x silently rejects the classic EQ preset ids (EQEBB_SET_PARAM is ACKed but no EQEBB_NTFY_PARAM follows and the preset does not change). The device only accepts HEAVY/CLEAR/HARD/SOFT (0x30-0x33), CUSTOM (0xA0) and the user settings, and reports one of the 0x30-family ids as its current preset, which the UI rendered as "Unknown" since FormatEnum had no case for them and the preset combo never offered them.

Add display names for the 0x30-family and gaming presets, offer them in the preset selector, and document the firmware behavior in the device support notes. Verified by RFCOMM packet capture on a WH-1000XM6 (FW 2.x): all four 0x30-family presets are ACKed and notified back; 0x10-0x17 and 0x20-0x23 remain rejected. Likely also relevant to the WF-1000XM6 preset issue (#33).