### PR TITLE
Harden `libmdr` protocol deserialization against malformed device input

### DIFF
--- a/libmdr/include/mdr/Protocol.hpp
+++ b/libmdr/include/mdr/Protocol.hpp
@@ -240,6 +240,7 @@ namespace mdr
 
         static size_t Read(const UInt8** ppSrcBuffer, MDRPrefixedString& str, size_t maxSize)
         {
+            MDR_CHECK_MSG(maxSize >= 1, "Not enough data to read string length");
             const UInt8 len = *(*ppSrcBuffer)++;
             maxSize--;
             MDR_CHECK_MSG(len <= maxSize, "Invalid string length");
@@ -277,9 +278,10 @@ namespace mdr
 
         static size_t Read(const UInt8** ppSrcBuffer, MDRPodArray& value, size_t maxSize)
         {
+            MDR_CHECK_MSG(maxSize >= 1, "Not enough data to read array count");
             UInt8 count = *(*ppSrcBuffer)++;
             size_t size = sizeof(T) * count;
-            MDR_CHECK_MSG(size <= maxSize, "Invalid array size");
+            MDR_CHECK_MSG(size + 1 <= maxSize, "Invalid array size");
             value.value.resize(count);
             std::memcpy(value.value.data(), *ppSrcBuffer, size);
             *ppSrcBuffer += size;
@@ -318,11 +320,15 @@ namespace mdr
         static size_t Read(const UInt8** ppSrcBuffer, MDRArray& value, size_t maxSize)
         {
             const UInt8* ptr = *ppSrcBuffer;
+            MDR_CHECK_MSG(maxSize >= 1, "Not enough data to read array count");
             UInt8 count = *(*ppSrcBuffer)++;
             maxSize--;
             value.value.resize(count);
-            for (T& elem : value.value)
-                maxSize -= T::Read(ppSrcBuffer, elem, maxSize);
+            for (T& elem : value.value) {
+                size_t bytesRead = T::Read(ppSrcBuffer, elem, maxSize);
+                MDR_CHECK_MSG(bytesRead <= maxSize, "Element read exceeded remaining buffer size");
+                maxSize -= bytesRead;
+            }
             return *ppSrcBuffer - ptr;
         }
 

--- a/libmdr/src/Command.cpp
+++ b/libmdr/src/Command.cpp
@@ -106,14 +106,22 @@ namespace mdr
         command = command.subspan(1, command.size() - 2);
         MDRBuffer unescaped = Unescape(command);
         command = unescaped;
+        if (command.size() < 7)
+            return MDRUnpackResult::INCOMPLETE;
         // Type,seq
         outType = static_cast<MDRDataType>(command[0]);
         outSeq = command[1];
         command = command.subspan(2);
         // Big-endian in
-        Int32BE outSize = command[0] << 24u | command[1] << 16u | command[2] << 8u | command[3];
+        uint32_t sizeVal = (static_cast<uint32_t>(command[0]) << 24u) |
+                           (static_cast<uint32_t>(command[1]) << 16u) |
+                           (static_cast<uint32_t>(command[2]) << 8u) |
+                           static_cast<uint32_t>(command[3]);
+        int32_t outSize = static_cast<int32_t>(sizeVal);
         Span<const UInt8> data = command.subspan(4);
         // Data...,checksum
+        if (data.empty())
+            return MDRUnpackResult::INCOMPLETE;
         UInt8 checksum = data.back();
         // Checksum incl. type,seq,data
         Span<const UInt8> checkData{unescaped.data(), unescaped.size()};
@@ -123,7 +131,7 @@ namespace mdr
             return MDRUnpackResult::BAD_CHECKSUM;
         // Data...
         data = data.subspan(0, data.size() - 1);
-        if (data.size() != static_cast<size_t>(outSize)) [[unlikely]]
+        if (outSize < 0 || data.size() != static_cast<size_t>(outSize)) [[unlikely]]
             return MDRUnpackResult::INCOMPLETE;
         outData.resize(data.size());
         std::ranges::copy(data, outData.begin());

--- a/libmdr/src/HeadphonesV2T1.cpp
+++ b/libmdr/src/HeadphonesV2T1.cpp
@@ -739,22 +739,38 @@ namespace mdr
         // XXX: Don't have the corresponding struct in the official app yet, and
         //      these don't get serialized in a way that's consistent with the rest.
         //      So excuse the rawdogged parsing - FIXME.
+        if (cmd.size() < 2)
+            return MDR_HEADPHONES_EVT_UNHANDLED;
+
         const UInt8* begin = nullptr;
+        size_t remaining = 0;
         switch (cmd[1])
         {
         case 0x00:
         {
             MDRPrefixedString res;
-            if (cmd[2])
+            if (cmd.size() > 2 && cmd[2])
+            {
                 begin = &cmd[2]; // key...
-            else
+                remaining = cmd.size() - 2;
+            }
+            else if (cmd.size() > 3)
+            {
                 begin = &cmd[3]; // op...
-            MDRPrefixedString::Read(&begin, res, cmd.size());
+                remaining = cmd.size() - 3;
+            }
+            else
+            {
+                return MDR_HEADPHONES_EVT_UNHANDLED;
+            }
+            MDRPrefixedString::Read(&begin, res, remaining);
             self->mLastDeviceJSONMessage = res.value;
             return MDR_HEADPHONES_EVT_OK;
         }
         case 0x01:
         {
+            if (cmd.size() < 4)
+                return MDR_HEADPHONES_EVT_UNHANDLED;
             self->mLastInteractionMessage = std::string(cmd.begin() + 4, cmd.end());
             return MDR_HEADPHONES_EVT_OK;
         }


### PR DESCRIPTION
This PR hardens the protocol parser and deserialization routines in `libmdr` to prevent potential out-of-bounds (OOB) memory reads and crashes when handling malformed, truncated, or hostile input from Bluetooth devices.