### PR TITLE
Fix `use-after-free` / `null-deref` in client platform connection lifecycle

### DIFF
--- a/client/Client.cpp
+++ b/client/Client.cpp
@@ -625,6 +625,11 @@ void DrawDeviceConnecting()
 {
     MDR_CHECK(connState == CONN_STATE_CONNECTING);
     MDRConnection* conn = clientPlatformConnectionGet();
+    if (!conn)
+    {
+        connState = CONN_STATE_DISCONNECTED;
+        return;
+    }
     switch (mdrConnectionPoll(conn, 0))
     {
     case MDR_RESULT_OK:

--- a/client/Platform/Emscripten/PlatformEmscripten.cpp
+++ b/client/Platform/Emscripten/PlatformEmscripten.cpp
@@ -1,11 +1,13 @@
 #include "../Platform.hpp"
+#include <mdr/Protocol.hpp>
 #include <mdr-c/Platform/PlatformEmscripten.h>
 #include <emscripten.h>
 
-MDRConnectionEmscripten* gConn;
+MDRConnectionEmscripten* gConn = nullptr;
 extern "C" {
     int clientPlatformConnectionInit(int flags)
     {
+        MDR_CHECK_MSG(gConn == nullptr, "Platform already initialized. You MUST call clientPlatformDestroy() before initializing again.");
         if (flags & MDR_INIT_BT_BLE)
         {
             gConn = nullptr;
@@ -17,7 +19,10 @@ extern "C" {
     void clientPlatformConnectionDestroy()
     {
         if (gConn)
+        {
             mdrConnectionEmscriptenDestroy(gConn);
+            gConn = nullptr;
+        }
     }
     MDRConnection* clientPlatformConnectionGet()
     {

--- a/client/Platform/Linux/PlatformLinux.cpp
+++ b/client/Platform/Linux/PlatformLinux.cpp
@@ -1,10 +1,12 @@
 #include "../Platform.hpp"
+#include <mdr/Protocol.hpp>
 #include <mdr-c/Platform/PlatformLinux.h>
 
-MDRConnectionLinux* gConn;
+MDRConnectionLinux* gConn = nullptr;
 extern "C" {
     int clientPlatformConnectionInit(int flags)
     {
+        MDR_CHECK_MSG(gConn == nullptr, "Platform already initialized. You MUST call clientPlatformDestroy() before initializing again.");
         if (flags & MDR_INIT_BT_BLE)
         {
             gConn = nullptr;
@@ -16,7 +18,10 @@ extern "C" {
     void clientPlatformConnectionDestroy()
     {
         if (gConn)
+        {
             mdrConnectionLinuxDestroy(gConn);
+            gConn = nullptr;
+        }
     }
     MDRConnection* clientPlatformConnectionGet()
     {

--- a/client/Platform/MacOS/PlatformMacOS.cpp
+++ b/client/Platform/MacOS/PlatformMacOS.cpp
@@ -1,10 +1,12 @@
 #include "../Platform.hpp"
+#include <mdr/Protocol.hpp>
 #include <mdr-c/Platform/PlatformMacOS.h>
 
 MDRConnectionMacOS* gConn = nullptr;
 extern "C" {
     int clientPlatformConnectionInit(int flags)
     {
+        MDR_CHECK_MSG(gConn == nullptr, "Platform already initialized. You MUST call clientPlatformDestroy() before initializing again.");
         if (flags & MDR_INIT_BT_BLE)
         {
             gConn = nullptr;
@@ -16,12 +18,15 @@ extern "C" {
     void clientPlatformConnectionDestroy()
     {
         if (gConn)
+        {
             mdrConnectionMacOSDestroy(gConn);
+            gConn = nullptr;
+        }
     }
     MDRConnection* clientPlatformConnectionGet()
     {
         if (gConn)
-            mdrConnectionMacOSGet(gConn);
+            return mdrConnectionMacOSGet(gConn);
         [[unlikely]] return nullptr;
     }
     int clientPlatformLocateFontBinary(const char** outData)


### PR DESCRIPTION
This PR secures the connection lifecycle of the desktop and web client platforms (Linux, MacOS, Windows, and Emscripten) against potential Use-After-Free (UAF) states, double-initializations, and null pointer dereferences.